### PR TITLE
Disable caching of runs.txt

### DIFF
--- a/main.js
+++ b/main.js
@@ -34,7 +34,7 @@ function init()
   var faces = document.querySelectorAll(".face");
   faces[Math.floor(Math.random() * faces.length)].classList.add("active");
   
-  fetch("runs.txt").then(function(resp) {
+  fetch("runs.txt", { cache: "no-cache" }).then(function(resp) {
     if (resp.ok)
     {
       return resp.text();


### PR DESCRIPTION
Since seeing it updated as soon as possible on the page is essential, fetch should not cache the response.